### PR TITLE
Fix for white background on menu table cells with the iOS7 SDK

### DIFF
--- a/iOS7Menu/Views/ISMViewController.m
+++ b/iOS7Menu/Views/ISMViewController.m
@@ -298,6 +298,8 @@ static const int SENSITIVE_AREA_FOR_OPENING_MENU = 40;
 
     menuCell.textLabel.text = [[[self.viewControllers objectAtIndex:(NSUInteger)indexPath.row] tabBarItem] title];
     menuCell.textLabel.textColor = [UIColor whiteColor];
+    
+    menuCell.backgroundColor = [UIColor clearColor];
 
     return menuCell;
 }


### PR DESCRIPTION
Just wanted to start off by saying this is a pretty slick menu, thanks.

When building with the iOS7 SDK though, the menu's table cells have a white background:

![White menu table cells with iOS7 SDK](https://dl.dropboxusercontent.com/u/1525722/iOS7Menu/white-menu-bg-with-ios7-sdk.png)

This pull request contains a small tweak to fix it.
